### PR TITLE
Migrate to split almanac collections (sites + funding)

### DIFF
--- a/layers-input.json
+++ b/layers-input.json
@@ -192,11 +192,11 @@
             ]
         },
         {
-            "collection_id": "conservation-almanac-2024",
-            "collection_url": "https://s3-west.nrp-nautilus.io/public-tpl/stac-collection.json",
+            "collection_id": "conservation-almanac-2024-sites",
+            "collection_url": "https://s3-west.nrp-nautilus.io/public-tpl/conservation-almanac-2024-sites/stac-collection.json",
             "assets": [
                 {
-                    "id": "almanac-pmtiles",
+                    "id": "conservation-almanac-2024-sites-pmtiles",
                     "display_name": "TPL Conservation Almanac",
                     "group": "Conservation Areas",
                     "visible": true,
@@ -210,7 +210,7 @@
                         ],
                         "fill-opacity": 0.6
                     },
-                    "tooltip_fields": ["site", "owner", "owner_type", "manager", "access_type", "purchase_type", "acres", "amount", "program", "year", "state", "county"]
+                    "tooltip_fields": ["site", "owner", "owner_type", "manager", "access_type", "purchase_type", "acres", "year", "state", "county"]
                 }
             ]
         },

--- a/system-prompt.md
+++ b/system-prompt.md
@@ -18,14 +18,20 @@ When describing Conservation Almanac data, do not say "TPL-protected land" or im
 - "conservation investment in this district"
 - "funding from [program name]" when a specific program is known
 
-### Key pitfalls
+### Two collections joined by `tpl_id`
 
-**A single conservation site often has multiple sponsors.** The Almanac has one row per funding transaction: if a site received money from three programs, it appears as three rows sharing the same `tpl_id`. The `program` column names the funding program, and `amount` is that sponsor's contribution.
+The Almanac is split into two collections. Use both together for any funding question.
 
-- **Funding:** `SUM(amount)` across all rows correctly totals funding — each row's `amount` is one sponsor's contribution.
-- **Acres:** `SUM(acres)` double-counts because acres is repeated on every funding row for the same site. Always deduplicate first: `SELECT tpl_id, MAX(acres) AS acres ... GROUP BY tpl_id`, then `SUM` the result. **Never write `SUM(MAX(acres))`** — nested aggregates are invalid SQL.
-- **Counting sites:** Use `COUNT(DISTINCT tpl_id)` to count physical conservation areas.
-- A site with `amount = 0` or null may still be significant — it may be a donation or a transaction where only acreage was recorded.
+- **`conservation-almanac-2024-sites`** — one row per protected site. Geometry, acres, ownership, access, year, location. **No funding info.** `SUM(acres)` is safe here.
+- **`conservation-almanac-2024-funding`** — one row per (site, program, sponsor) funding transaction. Amount, program, sponsor, sponsor_type. **No geometry, no hex variant.** `SUM(amount)` is safe — no geographic repetition.
+
+Join on `tpl_id`. `get_dataset('conservation-almanac-2024-sites')` includes a worked Texas federal-funding join example.
+
+**Coded-value gotcha across the two collections.** `owner_type` on sites uses `PVT` and `TRIB`; `sponsor_type` on funding uses `PRIV` and `TRB`. Verify coded values from `get_dataset` before filtering.
+
+A transaction with `amount = 0` or null may still be significant — it may be a donation or a record where only acreage was captured.
+
+A legacy flat `conservation-almanac-2024` collection still exists for backwards compatibility. Prefer the split collections — on the flat collection `SUM(acres)` double-counts and you must dedupe by `tpl_id` first. Do not use the flat collection unless a user explicitly asks for a single-table view.
 
 ## About LandVote
 


### PR DESCRIPTION
Closes #30. Tracks boettiger-lab/data-workflows#126.

## Changes

### `layers-input.json`
Point the almanac map layer at the new `conservation-almanac-2024-sites` collection:
- `collection_id`: `conservation-almanac-2024` → `conservation-almanac-2024-sites`
- `collection_url`: flat bucket URL → `.../conservation-almanac-2024-sites/stac-collection.json`
- Asset `id`: `almanac-pmtiles` → `conservation-almanac-2024-sites-pmtiles`
- PMTiles source-layer is now `conservation-almanac-2024-sites` (declared by the new collection's `vector:layers`)
- Drop `amount` and `program` from `tooltip_fields` — those columns live only on the separate funding collection (tabular-only, no PMTiles)

### `system-prompt.md`
Replace the single-collection "one row per funding transaction, dedup acres by tpl_id" guidance with the two-collection model:
- Sites → `SUM(acres)` is safe, no funding columns
- Funding → `SUM(amount)` is safe, no geometry
- Join by `tpl_id`
- Cross-collection coded-value gotcha: `owner_type` uses `PVT/TRIB`; `sponsor_type` uses `PRIV/TRB`
- Legacy flat collection retained for backwards compat with a note that it is not the preferred path

## Test plan

- [ ] Almanac map layer renders (pmtiles URL resolves, source-layer matches).
- [ ] Tooltip shows site attributes (no broken `amount`/`program` fields).
- [ ] Texas federal-funding question from boettiger-lab/data-workflows#125 uses `conservation-almanac-2024-funding` with a `tpl_id` join to sites + a congressional-district geo-join; turn count drops noticeably from the ~20-turn baseline.
- [ ] No regression on acreage-by-state or site-count queries.