### PR TITLE
Pin geo-agent to v3.3.0

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,8 +39,8 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/languages/sql.min.js"></script>
 
     <!-- Core styles from CDN -->
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@d7585e758b4071604d9695312f4476d2c916d46d/app/style.css">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@d7585e758b4071604d9695312f4476d2c916d46d/app/chat.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.3.0/app/style.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.3.0/app/chat.css">
 </head>
 
 <body>
@@ -68,7 +68,7 @@
     </div>
 
     <!-- Boot from CDN — pin @v1.0.0 for production, @main for dev -->
-    <script type="module" src="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@d7585e758b4071604d9695312f4476d2c916d46d/app/main.js"></script>
+    <script type="module" src="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.3.0/app/main.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
Align tpl with tpl-ca on the tagged v3.3.0 release. Previously pinned to commit `d7585e7` (PR #176 HEAD, one commit past v3.3.0 with a map-tools displayName fix). Moving to the tagged release for a reproducible immutable pin.