### PR TITLE
Pin geo-agent to latest main (chat-history export)

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,9 +39,9 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/languages/sql.min.js"></script>
 
     <!-- Core styles from CDN -->
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.7.0/app/style.css">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.7.0/app/chat.css">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.7.0/app/sidebar.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@c5e08c39161ebd39d5e092fa6c42bfd1a548617d/app/style.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@c5e08c39161ebd39d5e092fa6c42bfd1a548617d/app/chat.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@c5e08c39161ebd39d5e092fa6c42bfd1a548617d/app/sidebar.css">
 </head>
 
 <body>
@@ -54,7 +54,7 @@
     <!-- Chat scaffold is built dynamically by the sidebar layout manager (v3.2.0+). -->
 
     <!-- Boot from CDN — pin @v1.0.0 for production, @main for dev -->
-    <script type="module" src="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.7.0/app/main.js"></script>
+    <script type="module" src="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@c5e08c39161ebd39d5e092fa6c42bfd1a548617d/app/main.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
Updates the geo-agent CDN pin from `v3.7.0` to the latest `main` commit `c5e08c3` ("feat: HTML chat-history export with reproducible SQL", #227) across all four references in index.html (style.css, chat.css, sidebar.css, main.js).

jsDelivr serving the commit was verified (HTTP 200) before pinning.

Note: this pins to a development commit on main rather than a release tag.