### PR TITLE
Data migrations: canonical collection_url + WDPA/ghs-pop repoint

### DIFF
--- a/layers-input.json
+++ b/layers-input.json
@@ -341,7 +341,7 @@
         },
         {
             "collection_id": "ghs-pop-2020",
-            "collection_url": "https://s3-west.nrp-nautilus.io/public-high-seas/ghs-pop-2020/stac-collection.json",
+            "collection_url": "https://s3-west.nrp-nautilus.io/public-population/ghs-pop-2020/stac-collection.json",
             "assets": [
                 {
                     "id": "ghs-pop-2020-cog",


### PR DESCRIPTION
Data-catalog migrations (tracking boettiger-lab/geo-agent-ops#14, #15, #16):

- #15 ghs-pop-2020 `collection_url` → `public-population`

All target collection ids/urls verified against live STAC (ids match, referenced assets present).