### PR TITLE
Rename app to Trust for Public Land Explorer

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -11,7 +11,7 @@
       "affiliation": "University of California Berkeley"
     }
   ],
-  "title": "geo-agent: Trust for Public Land",
+  "title": "Trust for Public Land Explorer",
   "description": "An interactive conservation decision-support tool that integrates protected areas, conservation finance, climate, biodiversity, and social vulnerability data into a unified exploratory interface. The application is built on the geo-agent agentic framework, combining geospatial visualization with a natural-language agent that discovers datasets and generates SQL queries over H3-indexed spatial datasets through MCP tools, enabling real-time spatial joins across conservation investments, ballot measures, irrecoverable carbon, species richness, legislative districts, and environmental justice indicators to support rapid analysis of conservation patterns, gaps, and opportunities. Users can explore protected lands, funding flows, and socio-ecological priorities while dynamically intersecting datasets at multiple scales through on-the-fly H3 indexing and model-generated queries. The tool draws on public datasets including Trust for Public Land's Conservation Almanac and LandVote, the U.S. Climate and Economic Justice Screening Tool (Justice40), and the CDC Social Vulnerability Index, supporting multiple open-weights language models for reproducible, extensible conservation analytics and decision support.",
   "access_right": "open",
   "license": "bsd-2-clause",

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# geo-agent: Trust for Public Land
+# Trust for Public Land Explorer
 
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.18500623.svg)](https://doi.org/10.5281/zenodo.18500623)
 


### PR DESCRIPTION
Renames the application from "geo-agent: Trust for Public Land" to "Trust for Public Land Explorer".

- `README.md` heading
- `.zenodo.json` `title` field (will update the Zenodo deposit title on next release)