### PR TITLE
Bump geo-agent pin v3.9.0 → v3.12.0 (+ security hardening)

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,27 +21,48 @@
     </script>
 
     <!-- MapLibre GL JS -->
-    <script src="https://unpkg.com/maplibre-gl@5.22.0/dist/maplibre-gl.js"></script>
-    <link href="https://unpkg.com/maplibre-gl@5.22.0/dist/maplibre-gl.css" rel="stylesheet" />
+    <script src="https://unpkg.com/maplibre-gl@5.22.0/dist/maplibre-gl.js"
+        integrity="sha384-U054LTKiMIJKEecR8PKFiUZdvkGWHjfPBnen5hSmR9TwfOfgZmKbskC8Rs9dCm/1"
+        crossorigin="anonymous"></script>
+    <link href="https://unpkg.com/maplibre-gl@5.22.0/dist/maplibre-gl.css" rel="stylesheet"
+        integrity="sha384-MGCxhspF/+ufueUgol3FDkiAYQbpSNRhBT0VWHJt64U8qIy9qlnXWx8LAbj6niPH"
+        crossorigin="anonymous" />
 
     <!-- PMTiles protocol -->
-    <script src="https://unpkg.com/pmtiles@3.0.7/dist/pmtiles.js"></script>
+    <script src="https://unpkg.com/pmtiles@3.0.7/dist/pmtiles.js"
+        integrity="sha384-MjejsnWXHmuz93aE35YWLh5AbS/6ceRB3Vb+ukOwqFzJRTpQ8vvbkLbNV7I0QK4f"
+        crossorigin="anonymous"></script>
 
     <!-- h3-js (for hex grid overlay) -->
-    <script src="https://unpkg.com/h3-js@4.1.0/dist/h3-js.umd.js"></script>
+    <script src="https://unpkg.com/h3-js@4.1.0/dist/h3-js.umd.js"
+        integrity="sha384-nKUDlg+fT0U/eEt4KWP9n034kLe/eVj6k7CVjbu6qfRhJdEyinlGajS9+9AU+UZ5"
+        crossorigin="anonymous"></script>
 
     <!-- Markdown rendering -->
-    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/marked@18.0.5/lib/marked.umd.js"
+        integrity="sha384-ZD0fTOwPMHi7zM6WTVIWJR21I07lq0ccnqz3J6WMvQKG9thh4y7TA1QE6PJu0Af8"
+        crossorigin="anonymous"></script>
+
+    <!-- HTML sanitizer — chat-ui.js (v3.10.0+) refuses to render markdown without it -->
+    <script src="https://cdn.jsdelivr.net/npm/dompurify@3.4.8/dist/purify.min.js"
+        integrity="sha384-jrsBdrv4eDpEYIq32u13DPbvB6tRmqIDnA6UlgFBoexpetaiWi7g/VbfMEL1WVen"
+        crossorigin="anonymous"></script>
 
     <!-- Code highlighting -->
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css">
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/languages/sql.min.js"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css"
+        integrity="sha384-wH75j6z1lH97ZOpMOInqhgKzFkAInZPPSPlZpYKYTOqsaizPvhQZmAtLcPKXpLyH"
+        crossorigin="anonymous">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"
+        integrity="sha384-F/bZzf7p3Joyp5psL90p/p89AZJsndkSoGwRpXcZhleCWhd8SnRuoYo4d0yirjJp"
+        crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/languages/sql.min.js"
+        integrity="sha384-8q00eP+tyV9451aJYD5ML3ftuHKsGnDcezp7EXMEclDg1fZVSoj8O+3VyJTkXmWp"
+        crossorigin="anonymous"></script>
 
     <!-- Core styles from CDN -->
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.9.0/app/style.css">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.9.0/app/chat.css">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.9.0/app/sidebar.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.12.0/app/style.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.12.0/app/chat.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.12.0/app/sidebar.css">
 </head>
 
 <body>
@@ -54,7 +75,7 @@
     <!-- Chat scaffold is built dynamically by the sidebar layout manager (v3.2.0+). -->
 
     <!-- Boot from CDN — pin @v1.0.0 for production, @main for dev -->
-    <script type="module" src="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.9.0/app/main.js"></script>
+    <script type="module" src="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.12.0/app/main.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
Brings this app in line with geo-agent **v3.12.0** (latest release).

**index.html: security hardening + pin bump v3.9.0 → v3.12.0**
- Add Subresource Integrity (`integrity` + `crossorigin`) to all CDN assets (MapLibre, PMTiles, h3-js, marked, highlight.js).
- Pin + hash `marked@18.0.5/lib/marked.umd.js` (hashable build).
- Add **DOMPurify 3.4.8** — chat-ui.js (v3.10.0+) fail-closes markdown to escaped plain text without it.
- Bump geo-agent CDN pin v3.9.0 → v3.12.0 (style/chat[/sidebar] CSS + main.js).

The DOMPurify tag + pin bump land together (bumping the pin alone renders chat as escaped markdown).

**What v3.12.0 brings beyond the security tags (CDN-served app JS — no further app change):**
- v3.10.0 XSS sanitization + SRI (the head changes above).
- v3.11.0 DOI / v3.11.1 GLEN rebrand — metadata/display only; app keeps its own title/branding.
- v3.12.0 `set_filter` fixes (no infinite loop on grammar-constrained tool args; no false "no matches" for off-screen results) + opt-in geocoder.

Reference: identical pattern to bosl-high-seas #37. Hashes copied verbatim from the canonical v3.12.0 app — never hand-edited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
