### PR TITLE
k8s: drop retired SECRETS_EXPOSURE pointer from configmap comment

### DIFF
--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -4,8 +4,6 @@
 # which injects the Authorization header server-side via
 # `proxy_set_header`. The browser only sees a relative `/api/llm`
 # endpoint and never holds the key.
-#
-# See ../../geo-agent-ops/SECRETS_EXPOSURE.md for the migration plan.
 apiVersion: v1
 kind: ConfigMap
 metadata:


### PR DESCRIPTION
Manifest hygiene tracked in geo-agent-ops.

- **Drop the dangling `SECRETS_EXPOSURE.md` pointer** from the configmap comment — that doc was retired in geo-agent-ops@6be2c1e after the proxy-key leak was closed and the key rotated (April 2026). The surrounding "NO SECRETS / key lives only in nginx" comment stays.

No behavioral change — apps already run in this namespace.