### PR TITLE
ops: pin to v3.16.0 commit SHA (jsDelivr tag 502)

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,9 +60,9 @@
         crossorigin="anonymous"></script>
 
     <!-- Core styles from CDN -->
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.16.0/app/style.css">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.16.0/app/chat.css">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.16.0/app/sidebar.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@90d02eb0ad090dea46aa3cfbb2ffb8d9f0338d67/app/style.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@90d02eb0ad090dea46aa3cfbb2ffb8d9f0338d67/app/chat.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@90d02eb0ad090dea46aa3cfbb2ffb8d9f0338d67/app/sidebar.css">
 </head>
 
 <body>
@@ -75,7 +75,7 @@
     <!-- Chat scaffold is built dynamically by the sidebar layout manager (v3.2.0+). -->
 
     <!-- Boot from CDN — pin @v1.0.0 for production, @main for dev -->
-    <script type="module" src="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.16.0/app/main.js"></script>
+    <script type="module" src="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@90d02eb0ad090dea46aa3cfbb2ffb8d9f0338d67/app/main.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
Incident fix: jsDelivr 502s the @v3.16.0 tag; commit SHA 90d02eb (= v3.16.0) resolves 200. Re-pin to SHA to restore service; revert to @v3.16.0 once jsDelivr ingests the tag.