### PR TITLE
Fix inaccurate 'get_dataset' tool name in prompt & agent docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ The schema below is kept inline so you can work without a network fetch. If it c
 
 ### Writing the system prompt
 
-**Keep `system-prompt.md` lean.** The MCP query tool (`list_datasets`, `get_dataset`) already provides the agent with dataset titles, descriptions, column schemas, coded values, and exact S3 parquet paths at runtime. Do not duplicate any of this in the system prompt — it drifts out of sync and can contradict the tools.
+**Keep `system-prompt.md` lean.** The MCP query tool (`list_datasets`, `get_schema`) already provides the agent with dataset titles, descriptions, column schemas, coded values, and exact S3 parquet paths at runtime. Do not duplicate any of this in the system prompt — it drifts out of sync and can contradict the tools.
 
 What **belongs** in `system-prompt.md`:
 - Domain-specific context the tools cannot provide (e.g., "this dataset has one row per funding transaction, not per site — deduplicate acres before summing")
@@ -34,12 +34,12 @@ What **belongs** in `system-prompt.md`:
 - "Data tool, not advisor" guardrails if the agent should avoid giving policy opinions
 
 What **does not belong** in `system-prompt.md`:
-- Column listings or S3 paths (use `get_dataset` instead — direct the agent to call it)
+- Column listings or S3 paths (use `get_schema` instead — direct the agent to call it)
 - Multiple SQL examples with hardcoded paths (these go stale and may contradict the MCP tool's own query optimization rules)
 - DuckDB configuration details (thread count, extensions)
 - Dataset descriptions that repeat what's in the STAC catalog
 
-Instead, add a "Discovering data" section directing the agent to call `list_datasets` and `get_dataset` before writing any SQL.
+Instead, add a "Discovering data" section directing the agent to verify against the dataset metadata (via `list_datasets` / `get_schema`) before writing any SQL.
 
 ---
 

--- a/example-reports/query_answers.md
+++ b/example-reports/query_answers.md
@@ -9,7 +9,7 @@ Each example query from the welcome screen, with expected tool calls and answers
 > *"What conservation sites have been protected in Charlotte County, Florida, and which programs funded them?"*
 
 **Expected tool calls: ~4**
-`get_dataset` (almanac) · `query` · `zoom_to` · `toggle_layer`
+`get_schema` (almanac) · `query` · `zoom_to` · `toggle_layer`
 
 ### Conservation Almanac sites — Charlotte County, FL
 
@@ -41,7 +41,7 @@ Each example query from the welcome screen, with expected tool calls and answers
 > *"Where does irrecoverable carbon overlap with conserved land in Haywood County, North Carolina?"*
 
 **Expected tool calls: ~6**
-`get_dataset` ×2 (almanac, carbon) · `query` · `zoom_to` · `toggle_layer` ×2
+`get_schema` ×2 (almanac, carbon) · `query` · `zoom_to` · `toggle_layer` ×2
 
 ### Conservation Almanac sites — Haywood County, NC (Blue Ridge)
 
@@ -66,7 +66,7 @@ Each example query from the welcome screen, with expected tool calls and answers
 > *"What programs have funded the largest conservation sites in Chester County, Pennsylvania?"*
 
 **Expected tool calls: ~4**
-`get_dataset` (almanac) · `query` · `zoom_to` · `toggle_layer`
+`get_schema` (almanac) · `query` · `zoom_to` · `toggle_layer`
 
 ### Largest conservation sites — Chester County, PA
 
@@ -99,7 +99,7 @@ Each example query from the welcome screen, with expected tool calls and answers
 > *"Which Colorado counties have passed the most conservation funding since 2020?"*
 
 **Expected tool calls: ~4**
-`get_dataset` (landvote) · `query` · `zoom_to` · `set_filter`
+`get_schema` (landvote) · `query` · `zoom_to` · `set_filter`
 
 ### All passed measures, Colorado 2020–2025
 
@@ -127,7 +127,7 @@ Each example query from the welcome screen, with expected tool calls and answers
 > *"Are Monmouth County, NJ's conservation investments reaching vulnerable coastal communities? Show ballot measures alongside social vulnerability scores."*
 
 **Expected tool calls: ~6**
-`get_dataset` ×2 (landvote, svi-2022) · `query` ×2 · `zoom_to` · `toggle_layer`
+`get_schema` ×2 (landvote, svi-2022) · `query` ×2 · `zoom_to` · `toggle_layer`
 
 ### Passed ballot measures since 2017 (all property tax)
 


### PR DESCRIPTION
Part of a fleet-wide sweep (boettiger-lab/geo-agent-template#22).

`get_dataset` / `get_dataset_details` are **not registered tools**. The real client-side tools are `get_schema` (delegates to MCP `get_stac_details`) and `list_datasets`.

- **system-prompt.md**: de-named — verify against the dataset metadata rather than naming tools (definitions come from the MCP runtime, so hard-coded names go stale).
- **agent guide / docs**: corrected `get_dataset` -> `get_schema`.