### PR TITLE
Make DSE-nimbus (qwen) the default model (reconcile main)

### DIFF
--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -13,7 +13,7 @@ data:
   config.template.json: |
     {
         "mcp_server_url": "${MCP_SERVER_URL}",
-        "llm_model": "qwen3",
+        "llm_model": "qwen",
         "llm_models": [
             {
                 "value": "qwen",


### PR DESCRIPTION
Lands `llm_model: qwen` (DSE-nimbus) as the boot default. The default-model commit was dropped from the squash of the earlier model PR — only the picker-entry commit landed on main, leaving `llm_model: qwen3` here even though the deployed pod already serves `qwen`. This reconciles origin/main with deployed reality. Part of the → DSE-nimbus (qwen) default migration (geo-agent-ops MIGRATIONS.md).