### PR TITLE
chore: gitignore .ipynb_checkpoints/ and .vscode/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 .claude/
+
+# Editor / notebook artifacts
+.ipynb_checkpoints/
+.vscode/


### PR DESCRIPTION
Fleet-wide hygiene: adds `.ipynb_checkpoints/` (Jupyter) and `.vscode/` (editor settings) to `.gitignore` so these local artifacts stop showing as untracked.