### PR TITLE
Migrate NLCD off the retired standalone nlcd-2024 collection

### DIFF
--- a/layers-input.json
+++ b/layers-input.json
@@ -393,11 +393,11 @@
             ]
         },
         {
-            "collection_id": "nlcd-2024",
-            "collection_url": "https://s3-west.nrp-nautilus.io/public-land-cover/nlcd-2024/stac-collection.json",
+            "collection_id": "nlcd",
+            "collection_url": "https://s3-west.nrp-nautilus.io/public-land-cover/nlcd/stac-collection.json",
             "assets": [
                 {
-                    "id": "nlcd-2024-cog",
+                    "id": "nlcd-cog-2024",
                     "display_name": "Land Cover (NLCD 2024)",
                     "group": "Land Cover",
                     "visible": false,


### PR DESCRIPTION
Part of the coordinated migration in [geo-agent-ops#105](https://github.com/boettiger-lab/geo-agent-ops/issues/105) — every consuming app must move **before** the old data is purged.

## What changed

| | old | new |
|---|---|---|
| `collection_id` | `nlcd-2024` | `nlcd` |
| `collection_url` | `…/public-land-cover/nlcd-2024/stac-collection.json` | `…/public-land-cover/nlcd/stac-collection.json` |
| asset `id` | `nlcd-2024-cog` | `nlcd-cog-2024` |

**1:1 swap — the layer list is unchanged**, still a single 2024 land-cover layer. The unified collection also carries 18 other years (`nlcd-cog-<year>`, 1985–2025) and the year-partitioned `nlcd-hex` / `nlcd-hex-fractions`; the agent can reach those through MCP without pinning them here. Adding a year dropdown is a separate product decision, deliberately not bundled into this migration.

## ⚠️ Not a pure rename

The old standalone collection was MRLC **C1V1**; the unified collection's 2024 is **C1V2** (MRLC reprocessing). Migrated apps get slightly different 2024 pixel/class values — not identical bytes.

## Verified before opening

- New collection is live (200) and its STAC `id` is `nlcd`.
- Asset `nlcd-cog-2024` exists in it (one of 19 yearly COGs).
- Old collection is still live, so nothing 404s mid-cutover.
- `layers-input.json` still parses as valid JSON.
- This repo has **no** references to `nlcd-2024-hex` / `-hex-fractions`, so the hex `WHERE year=2024` half of the migration mapping does not apply here.