### PR TITLE
chore: bump geo-agent pin v3.23.0 → v3.25.0

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,9 +60,9 @@
         crossorigin="anonymous"></script>
 
     <!-- Core styles from CDN -->
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.23.0/app/style.css">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.23.0/app/chat.css">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.23.0/app/sidebar.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.25.0/app/style.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.25.0/app/chat.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.25.0/app/sidebar.css">
 </head>
 
 <body>
@@ -75,7 +75,7 @@
     <!-- Chat scaffold is built dynamically by the sidebar layout manager (v3.2.0+). -->
 
     <!-- Boot from CDN — pin @v1.0.0 for production, @main for dev -->
-    <script type="module" src="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.23.0/app/main.js"></script>
+    <script type="module" src="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.25.0/app/main.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
Fleet-wide roll to the current geo-agent release, `@v3.25.0`.

**Pin-only.** All four `app/` asset refs in `index.html` move together; no config, layer, or model changes ride along.

## Pre-checked before rolling

Per the standing rule in APPS.md — *always probe that the CDN serves a new tag before rolling it out* — jsDelivr was confirmed to return **200** for all four asset paths at `@v3.25.0`:

| path | status |
|---|---|
| `app/main.js` | 200 |
| `app/chat.css` | 200 |
| `app/sidebar.css` | 200 |
| `app/style.css` | 200 |

## Rollout

After merge: `kubectl rollout restart` so the git-clone init container re-clones, then the live pin is verified by curl (or in-pod for the auth app).

Coordinated in geo-agent-ops — APPS.md `Pin` column and a MIGRATIONS.md entry land in the same batch.
